### PR TITLE
chore: fix Dockerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,9 @@ LABEL summary="Provides the segment data collection service"
 LABEL com.redhat.component="segment-collection"
 
 COPY . /opt/app-root/src
+
 RUN mkdir /tmp/bin && curl https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 > /tmp/bin/jq && \
     chmod 755 /tmp/bin/jq && mkdir /tmp/oc && \
-    curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz > /tmp/oc/openshift-client-linux.tar.gz && \
-    tar xvf /tmp/oc/openshift-client-linux.tar.gz && cd /tmp/oc/ && mv oc /tmp/bin/oc && export PATH=$PATH:/tmp/bin/ && python3 -m pip install analytics
+    curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz > /tmp/oc/openshift-client-linux.tar.gz && cd /tmp/oc && \
+    tar xvf openshift-client-linux.tar.gz && export PATH=$PATH:/tmp/oc && \
+    python3 -m pip install analytics


### PR DESCRIPTION
The `oc` binary was being extracted to `$PWD` so I just moved the `cd` command to happen before that. Also eliminated the move to `/tmp/bin`. It seemed just as reasonable to set `/tmp/oc` in the PATH.