### PR TITLE
pipeline: prefetch dependencies

### DIFF
--- a/.tekton/segment-backup-job-pull-request.yaml
+++ b/.tekton/segment-backup-job-pull-request.yaml
@@ -31,6 +31,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"path": ".", "type": "pip"}'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -202,7 +204,7 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.hermetic)
+      - input: $(params.prefetch-input)
         operator: in
         values:
         - "true"

--- a/.tekton/segment-backup-job-push.yaml
+++ b/.tekton/segment-backup-job-push.yaml
@@ -27,6 +27,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"path": ".", "type": "pip"}'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -198,7 +200,7 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.hermetic)
+      - input: $(params.prefetch-input)
         operator: in
         values:
         - "true"


### PR DESCRIPTION
Enables the cachi2 task to prefetch the dependencies, required by the Enterprise Contract, and a precursor to hermetic builds.