### PR TITLE
fix: using wrong user and org id

### DIFF
--- a/main-installation.py
+++ b/main-installation.py
@@ -1,7 +1,17 @@
 import analytics
 import os
+import logging
+import datetime
+
+logging.getLogger('segment').setLevel('DEBUG')
+
+today = datetime.date.today()
+
+def on_error(error, items):
+    print("An error occurred:", error)
 
 analytics.write_key = 'jwq6QffjZextbffljhUjL5ODBcrIvsi5'
+
 
 user={}
 data={}
@@ -16,14 +26,17 @@ with open('./tmp', 'r') as file:
             user["alg_id"] = line[8:len(line)-1]
         if "sub_id:" in line:
             user["sub_id"] = line[8:len(line)-1]
-analytics.track(
-  user["user_id"], 
-  'New Install', 
-  {
-    'installation_uuid': user["sub_id"]
-  },
-  {
-    'groupId': user["org_id"],
-  }
-)
+    # analytics.debug = True
+    analytics.on_error = on_error
+    analytics.track(
+      user["user_id"], 
+      'New Install', 
+      {
+        'installation_uuid': user["sub_id"]
+      },
+      {
+        'groupId': user["org_id"],
+      }
+    )
+    analytics.flush()
 


### PR DESCRIPTION
Changes:

1. Swapped logging back to standard now that entries are coming through in segment
2. Fine-tuning on nightly metrics parsing of the `tmp` config file
3. Better analytics practices (flushing after setting / sending metrics)
4. User and Org Id were being grabbed from the `registry.redhat.io` config in the pull-secret instead of using the two values we added to the top level of the pull-secret. This now makes them clean numerical values