### PR TITLE
chore: update github action to pass images

### DIFF
--- a/.github/workflows/cronjobs.yaml
+++ b/.github/workflows/cronjobs.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Every M-F at 12:00am run this job
     - cron:  "0 0 * * 1-5"
-    
+
 jobs:
   check-image-version:
     uses: securesign/actions/.github/workflows/check-image-version.yaml@main
@@ -13,5 +13,6 @@ jobs:
         branch: [main]
     with:
       branch: ${{ matrix.branch }}
+      images: '["registry.redhat.io/openshift4/ose-tools-rhel8", "registry.redhat.io/ubi9/python-311"]'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The image update github action has been changed to accept image names.