### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for segment-backup-job

### DIFF
--- a/Dockerfile.segment-backup-job.rh
+++ b/Dockerfile.segment-backup-job.rh
@@ -6,7 +6,8 @@ LABEL io.k8s.display-name="segment collection"
 LABEL io.openshift.tags="segment,segment-collection"
 LABEL summary="Provides the segment data collection service"
 LABEL com.redhat.component="segment-collection"
-LABEL name="segment-collection"
+LABEL name="rhtas/segment-reporting-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 
 USER 0


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Fix segment-backup-job Dockerfile by adding NAME and CPE labels required for Clair to lookup the image in VEX statements

Enhancements:
- Add NAME label to Dockerfile.segment-backup-job.rh
- Add CPE label to Dockerfile.segment-backup-job.rh for Clair integration