### PR TITLE
Removing cpe label

### DIFF
--- a/Dockerfile.segment-backup-job.rh
+++ b/Dockerfile.segment-backup-job.rh
@@ -7,7 +7,6 @@ LABEL io.openshift.tags="segment,segment-collection"
 LABEL summary="Provides the segment data collection service"
 LABEL com.redhat.component="segment-collection"
 LABEL name="rhtas/segment-reporting-rhel9"
-LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 
 USER 0


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Delete the cpe label from Dockerfile.segment-backup-job